### PR TITLE
Fix agave-cli missing cargo-build-sbf and some dcou packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
                 solc --version
                 lsh --version
                 solana --version
+                cargo-build-sbf --version
                 solana-test-validator --version
                 mkdir $out
               '';


### PR DESCRIPTION
- added isolation of dcou packages as in agave master just to be safe/futureproof
- packaged some missing bins including cargo-build-sbf
- generate and package the sbf header files